### PR TITLE
Runtastic was aquired by Adidas in 2015

### DIFF
--- a/axelspringer-hosts
+++ b/axelspringer-hosts
@@ -325,7 +325,6 @@
 0.0.0.0 www.dnn-online.de
 0.0.0.0 www.europeanvoice.com
 0.0.0.0 www.sports.pl
-0.0.0.0 www.runtastic.com
 0.0.0.0 www.blic.rs
 
 0.0.0.0 springer02.webtrekk.net


### PR DESCRIPTION
Removed runtastic.com, as Axel Springer's remaining shares were bought by Adidas in 2015.