### PR TITLE
add bike-bild.de

### DIFF
--- a/axelspringer-hosts
+++ b/axelspringer-hosts
@@ -102,6 +102,8 @@
 0.0.0.0 www.beobachter.ch
 0.0.0.0 beobachtertv.ch
 0.0.0.0 www.beobachtertv.ch
+0.0.0.0 bike-bild.de
+0.0.0.0 www.bike-bild.de
 0.0.0.0 bilanz-magazin.de
 0.0.0.0 www.bilanz-magazin.de
 0.0.0.0 bild.de

--- a/www-hostnames
+++ b/www-hostnames
@@ -51,6 +51,7 @@ bams.de
 belvilla.com
 beobachter.ch
 beobachtertv.ch
+bike-bild.de
 bilanz-magazin.de
 bild.de
 blic.rs


### PR DESCRIPTION
Added bike-bild.de which is a website from Axel Springer Verlag (source: imprint of bike bild).