### PR TITLE
remove runtastic

### DIFF
--- a/axelspringer-hosts
+++ b/axelspringer-hosts
@@ -262,8 +262,6 @@
 0.0.0.0 www.radionrw.de
 0.0.0.0 rollingstone.de
 0.0.0.0 www.rollingstone.de
-0.0.0.0 runtastic.com
-0.0.0.0 www.runtastic.com
 0.0.0.0 schweizerbank.ch
 0.0.0.0 www.schweizerbank.ch
 0.0.0.0 schweizerversicherung.ch

--- a/ios-adguard.txt
+++ b/ios-adguard.txt
@@ -129,7 +129,6 @@ przegladsportowy.pl
 radiohamburg.de
 radionrw.de
 rollingstone.de
-runtastic.com
 schweizerbank.ch
 schweizerversicherung.ch
 seloger.com

--- a/www-hostnames
+++ b/www-hostnames
@@ -131,7 +131,6 @@ przegladsportowy.pl
 radiohamburg.de
 radionrw.de
 rollingstone.de
-runtastic.com
 schweizerbank.ch
 schweizerversicherung.ch
 seloger.com


### PR DESCRIPTION
Runtastic purchased 50,1% of runtastic in 2013.
In 2015 Adidas bought 100% of runtastic though. So since 2015 it is no longer a company by Axel Springer.

One source: https://en.wikipedia.org/wiki/Runtastic