### PR TITLE
onmeda.de has been sold to Funke (that is not part of AS)

### DIFF
--- a/axelspringer-hosts
+++ b/axelspringer-hosts
@@ -232,10 +232,6 @@
 0.0.0.0 www.ok-magazine.ru
 0.0.0.0 onet.pl
 0.0.0.0 www.onet.pl
-0.0.0.0 onmeda.de
-0.0.0.0 www.onmeda.de
-0.0.0.0 onmeda.de
-0.0.0.0 www.onmeda.de
 0.0.0.0 opineo.pl
 0.0.0.0 www.opineo.pl
 0.0.0.0 ozy.com

--- a/ios-adguard.txt
+++ b/ios-adguard.txt
@@ -114,8 +114,6 @@ noizz.pl
 ofeminin.pl
 ok-magazine.ru
 onet.pl
-onmeda.de
-onmeda.de
 opineo.pl
 ozy.com
 partyguide.ch

--- a/www-hostnames
+++ b/www-hostnames
@@ -116,8 +116,6 @@ noizz.pl
 ofeminin.pl
 ok-magazine.ru
 onet.pl
-onmeda.de
-onmeda.de
 opineo.pl
 ozy.com
 partyguide.ch


### PR DESCRIPTION
Sources:

https://www.funkemedien.de/de/presse/medienmitteilungen/news/FUNKE-forciert-Digitaloffensive-und-uebernimmt-fuehrendes-Gesundheitsportal-Onmeda.de/
https://www.horizont.net/medien/nachrichten/gesundheitsportal-funke-digital-uebernimmt-onmeda.de-188981?crefresh=1
https://www.wuv.de/medien/funke_uebernimmt_gesundheitsportal_onmeda_de