### PR TITLE
Remove Dresdner Neueste Nachrichten

### DIFF
--- a/axelspringer-hosts
+++ b/axelspringer-hosts
@@ -130,10 +130,6 @@
 0.0.0.0 www.computerbild.de
 0.0.0.0 computerbildspiele.de
 0.0.0.0 www.computerbildspiele.de
-0.0.0.0 dnn-online.de
-0.0.0.0 www.dnn-online.de
-0.0.0.0 dnn.de
-0.0.0.0 www.dnn.de
 0.0.0.0 dzienniksport.pl
 0.0.0.0 www.dzienniksport.pl
 0.0.0.0 ein-herz-fuer-kinder.de

--- a/ios-adguard.txt
+++ b/ios-adguard.txt
@@ -63,8 +63,6 @@ carwale.com
 casamundo.com
 computerbild.de
 computerbildspiele.de
-dnn-online.de
-dnn.de
 dzienniksport.pl
 ein-herz-fuer-kinder.de
 eprofessional.de

--- a/www-hostnames
+++ b/www-hostnames
@@ -65,8 +65,6 @@ carwale.com
 casamundo.com
 computerbild.de
 computerbildspiele.de
-dnn-online.de
-dnn.de
 dzienniksport.pl
 ein-herz-fuer-kinder.de
 eprofessional.de


### PR DESCRIPTION
AS' share of DNN was sold to Madsack in 2009:
https://web.archive.org/web/20090305094011/http://www.kress.de/cont/story.php?id=126492
https://de.wikipedia.org/wiki/Dresdner_Neueste_Nachrichten

Current shareholder profile shows no affiliation with AS:
https://www.kek-online.de/medienkonzentration/mediendatenbank#/profile/media/5be1a6b1-0a0b-42ac-b845-1914e17d572f