### PR TITLE
Added politico.com and protocol.com

### DIFF
--- a/axelspringer-hosts
+++ b/axelspringer-hosts
@@ -244,8 +244,12 @@
 0.0.0.0 www.pme.ch
 0.0.0.0 politico.eu
 0.0.0.0 www.politico.eu
+0.0.0.0 politico.com
+0.0.0.0 www.politico.com
 0.0.0.0 profession.hu
 0.0.0.0 www.profession.hu
+0.0.0.0 protocol.com
+0.0.0.0 www.protocol.com
 0.0.0.0 przegladsportowy.pl
 0.0.0.0 www.przegladsportowy.pl
 0.0.0.0 radiohamburg.de

--- a/ios-adguard.txt
+++ b/ios-adguard.txt
@@ -120,7 +120,9 @@ playpc.pl
 plejada.pl
 pme.ch
 politico.eu
+politico.com
 profession.hu
+protocol.com
 przegladsportowy.pl
 radiohamburg.de
 radionrw.de

--- a/www-hostnames
+++ b/www-hostnames
@@ -122,7 +122,9 @@ playpc.pl
 plejada.pl
 pme.ch
 politico.eu
+politico.com
 profession.hu
+protocol.com
 przegladsportowy.pl
 radiohamburg.de
 radionrw.de


### PR DESCRIPTION
> The publishing group Axel Springer signed an agreement to acquire POLITICO, including the remaining 50 percent share of its current joint venture POLITICO Europe, as well as the tech news website Protocol from Robert Allbritton. 
> Source: https://www.axelspringer.com/en/press-releases/axel-springer-to-acquire-politico