### PR TITLE
casamundo entfernt. Wurde 2018 von Home2Go übernommen

### DIFF
--- a/axelspringer-hosts
+++ b/axelspringer-hosts
@@ -164,8 +164,6 @@
 0.0.0.0 www.caribbeanjobs.com
 0.0.0.0 carwale.com
 0.0.0.0 www.carwale.com
-0.0.0.0 casamundo.com
-0.0.0.0 www.casamundo.com
 0.0.0.0 caterer.com
 0.0.0.0 www.caterer.com
 0.0.0.0 computerbild.de

--- a/ios-adguard.txt
+++ b/ios-adguard.txt
@@ -80,7 +80,6 @@ candidatemanager.net
 careerjunction.co.za
 caribbeanjobs.com
 carwale.com
-casamundo.com
 caterer.com
 computerbild.de
 computerbildspiele.de

--- a/www-hostnames
+++ b/www-hostnames
@@ -82,7 +82,6 @@ candidatemanager.net
 careerjunction.co.za
 caribbeanjobs.com
 carwale.com
-casamundo.com
 caterer.com
 computerbild.de
 computerbildspiele.de


### PR DESCRIPTION
https://www.wer-zu-wem.de/firma/casamundo.html